### PR TITLE
Add postgresql-devel to installed packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM fedora:28
-RUN dnf install python-pip git wget -y python37
+RUN dnf install -y python-pip git wget python37 postgresql-devel
 RUN pip install -U pip tox setuptools setuptools-scm pre-commit devpi-client
 RUN wget https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz
 RUN tar -xvf openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM fedora:28
 RUN dnf install -y python-pip git wget python37 postgresql-devel
+RUN dnf groupinstall -y 'Development Tools'
 RUN pip install -U pip tox setuptools setuptools-scm pre-commit devpi-client
 RUN wget https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz
 RUN tar -xvf openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz


### PR DESCRIPTION
Installing SQLAlchemy on this image is failing due to its requirement on psycopg2 which tries to build and complains that `pg_config` is not present. I haven't figured out how to get SQLAlchemy to install the psycopg2-binary instead of building psycopg2 from source so ... adding the postgresql-devel package in the image fixes this.