### PR TITLE
Pinned gitlab-helper image tag

### DIFF
--- a/helper.Dockerfile
+++ b/helper.Dockerfile
@@ -1,4 +1,4 @@
-FROM gitlab/gitlab-runner-helper:x86_64-latest
+FROM gitlab/gitlab-runner-helper:x86_64-448c28a9
 
 ENV HOME=/home/workspace
 


### PR DESCRIPTION
Due to a bug https://gitlab.com/gitlab-org/gitlab-runner/-/issues/26632 we have to pin helper image tag.